### PR TITLE
Remove lib.name compatibility shim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,3 @@ description = "panic in debug, intrinsics::unreachable() in release (fork of deb
 documentation = "https://docs.rs/new_debug_unreachable"
 readme = "README.md"
 license = "MIT"
-
-[lib]
-name = "debug_unreachable"
-path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "new_debug_unreachable"
-version = "1.0.4"
+version = "2.0.0"
 authors = ["Matt Brubeck <mbrubeck@limpet.net>", "Jonathan Reem <jonathan.reem@gmail.com>"]
 repository = "https://github.com/mbrubeck/rust-debug-unreachable"
 description = "panic in debug, intrinsics::unreachable() in release (fork of debug_unreachable)"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ with the rest of your dependencies:
 
 ```toml
 [dependencies]
-new_debug_unreachable = "1.0"
+new_debug_unreachable = "2.0"
 ```
 
 In your Rust code you can add debug-only assertions like this:
@@ -30,6 +30,30 @@ fn main() {
     }
 }
 ```
+
+This will panic if the unexpected branch is actually taken in a
+a debug build, so the failure can be analyzed. In a release build
+the macro will allow silent failure, hinting to the compiler that
+the branch is unlikely, optimizing for performance.
+
+## Updating from earlier versions
+
+The v1 releases of `new_debug_unreachable` tried to be a drop-in
+replacement for the v0.1 `debug_unreachable` crate, exporting
+the same name so only Cargo.toml needed to changed, not the
+referring Rust code.
+
+Since v2, this crate exports the `debug_unreachable!` macro under
+its default crate namespace, which is less confusing. This means
+that code upgrading will need to change statements like
+
+    use debug_unreachable::debug_unreachable;
+
+to
+
+    use new_debug_unreachable::debug_unreachable;
+
+when updating to v2 or later.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ with the rest of your dependencies:
 new_debug_unreachable = "1.0"
 ```
 
-In your Rust code, the library name is still `debug_unreachable`:
+In your Rust code you can add debug-only assertions like this:
 
 ```rust
-use debug_unreachable::debug_unreachable;
+use new_debug_unreachable::debug_unreachable;
 
 fn main() {
     if 0 > 100 {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,4 +1,4 @@
-use debug_unreachable::debug_unreachable;
+use new_debug_unreachable::debug_unreachable;
 
 fn main() {
     if 0 > 100 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 /// Example:
 ///
 /// ```
-/// use debug_unreachable::debug_unreachable;
+/// use new_debug_unreachable::debug_unreachable;
 ///
 /// fn main() {
 ///     if 0 > 100 {
@@ -33,4 +33,3 @@ macro_rules! debug_unreachable {
         }
     }
 }
-

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -2,7 +2,7 @@
 #[should_panic]
 #[cfg(debug_assertions)]
 fn explodes_in_debug() {
-    use debug_unreachable::debug_unreachable;
+    use new_debug_unreachable::debug_unreachable;
     unsafe { debug_unreachable!() }
 }
 


### PR DESCRIPTION
This is a suggestion to remove the `lib.name = "debug_unreachable"` compatibility shim in Cargo.toml, if you'll consider it.

We tripped over this trying to integrate the dependency into a non-cargo build. That's our tooling bug, but in generally I think it's better to keep the crate name and namespace aligned and let the client do any necessary renaming to avoid collisions. It should be a one-line change for most files.

Unfortunately, I think this has to be a major semver bump. At least, I couldn't think of a way to mark the old usage as deprecated for a more gentle transition.